### PR TITLE
remove emoji styles and scripts

### DIFF
--- a/functions/cleanup.php
+++ b/functions/cleanup.php
@@ -162,6 +162,10 @@ remove_action('wp_head', 'feed_links_extra', 3);
 remove_action('wp_head', 'start_post_rel_link', 10, 0);
 remove_action('wp_head', 'parent_post_rel_link', 10, 0);
 remove_action('wp_head', 'adjacent_posts_rel_link', 10, 0);
+remove_action('wp_head', 'print_emoji_detection_script', 7);
+remove_action('admin_print_scripts', 'print_emoji_detection_script');
+remove_action('wp_print_styles', 'print_emoji_styles');
+remove_action('admin_print_styles', 'print_emoji_styles');
 
 /**
  * Remove script and style from plugin Contact Form 7.


### PR DESCRIPTION
Remove emoji ```styles``` and ```scripts``` added on [WordPress 4.2](https://codex.wordpress.org/Version_4.2#Emoji)